### PR TITLE
133_layout-pages-myprofile

### DIFF
--- a/src/pages/page-download-success-profile.html
+++ b/src/pages/page-download-success-profile.html
@@ -21,88 +21,96 @@ This code may only be used under the license found at https://github.com/swarmci
     -->
         <style include="shared-styles">
            :host {
-              @apply --titlepage-closed;
-            }
+            @apply --titlepage-closed;
+        }
 
-            .container {
-                background-image: var(--sc-bg);
-              @apply --titlepage-closed-container;
-            }
-            .container .top {
-              @apply --titlepage-closed-container-top;
-            }
-            .container .bottom {
-              @apply --titlepage-closed-container-bottom;
-            }
-            .container .title {
-              @apply --titlepage-title;
-              color: var(--sc-blue);
-            }
-            .container .subtitle {
-              @apply --titlepage-subtitle;
-              color: var(--sc-grey4);
-            }
+        .container {
+            background-image: var(--sc-bg);
+            @apply --titlepage-closed-container;
+        }
 
-            .container[wide-layout] {
-              @apply --titlepage-closed-wide-container;
-            }
-            .container[wide-layout] .top {
-              @apply --titlepage-closed-wide-container-top;
-            }
-            .container[wide-layout] .bottom {
-              @apply --titlepage-closed-wide-container-bottom;
-            }
-            .container[wide-layout] .title {
-              @apply --titlepage-title-wide;
-            }
-            .container[wide-layout] .subtitle {
-              @apply --titlepage-subtitle-wide;
-            }
+        .container .top {
+            @apply --titlepage-closed-container-top;
+        }
 
-            .button {
-                @apply --layout-horizontal;
-                @apply --layout-center-justified;
-                @apply --text-button-big-fullwhite;
-                white-space: nowrap;
-                width: 100%;
-                max-width: 320px;
-            }
+        .container .bottom {
+            @apply --titlepage-closed-container-bottom;
+        }
 
-            .container[wide-layout] .button {
-                margin-top: 0px;
-            }
+        .container .title {
+            @apply --titlepage-title;
+            color: var(--sc-blue);
+        }
 
-            .button:active {
-                @apply --button-active;
-            }
+        .container .subtitle {
+            @apply --titlepage-subtitle;
+            color: var(--sc-grey4);
+        }
 
-            .bluetext {
-                @apply --small-bold;
-                cursor: pointer;
-                color: var(--sc-blue);
-                border-bottom: 2px dotted var(--sc-blue);
-                margin-top: 4vh;
-            }
+        .container[wide-layout] {
+            @apply --titlepage-closed-wide-container;
+        }
 
-            .flexer {
-               @apply --titlepage-flexer;
-            }
+        .container[wide-layout] .top {
+            @apply --titlepage-closed-wide-container-top;
+        }
+
+        .container[wide-layout] .bottom {
+            @apply --titlepage-closed-wide-container-bottom;
+        }
+
+        .container[wide-layout] .title {
+            @apply --titlepage-title-wide;
+        }
+
+        .container[wide-layout] .subtitle {
+            @apply --titlepage-subtitle-wide;
+        }
+
+        .button {
+            @apply --layout-horizontal;
+            @apply --layout-center-justified;
+            @apply --text-button-big-fullwhite;
+            white-space: nowrap;
+            width: 100%;
+            max-width: 320px;
+        }
+
+        .container[wide-layout] .button {
+            margin-top: 0px;
+        }
+
+        .button:active {
+            @apply --button-active;
+        }
+
+        .bluetext {
+            @apply --small-bold;
+            cursor: pointer;
+            color: var(--sc-blue);
+            border-bottom: 2px dotted var(--sc-blue);
+            margin-top: 4vh;
+        }
+        .flexer {
+           @apply --titlepage-flexer;
+        }
 
         </style>
 
-        <app-location route="{{route}}"></app-location>
-        <iron-media-query query="(min-width: 600px)" query-matches="{{wide}}"></iron-media-query>
-        <div class="container" wide-layout$="{{wide}}">
-            <div class="top">
-                <div class="title">{{localize('Success!')}}</div>
-                <div class="subtitle">{{localize('Youve downloaded your account file.')}}</div>
-                <div class="subtitle">{{localize('Your account file combined with your password will always give you access to your SWT balance.')}}</div>
-            </div>
-            <div class="flexer"></div>
-            <div class="bottom">
-                <div class="button" on-click="_back">{{localize('back to profile')}}</div>
-            </div>
+    <app-location route="{{route}}"></app-location>
+    <iron-media-query query="(min-width: 600px)" query-matches="{{wide}}"></iron-media-query>
+    <div class="container" wide-layout$="{{wide}}">
+        <div class="top">
+            <div class="title">{{localize('Success!')}}</div>
+            <div class="subtitle">{{localize('Youve downloaded your account file.')}}</div>
+            <div class="subtitle">{{localize('Your account file combined with your password will always give you access to your SWT balance.')}}</div>
         </div>
+        <div class="flexer"></div>
+        <div class="bottom">
+            <div class="button" on-click="_enter">{{localize('enter swarm.city')}}</div>
+            <!-- <div class="bluetext">{{localize('convert my ARC')}}</div> -->
+        </div>
+    </div>
     </template>
 
     <script>

--- a/src/pages/page-email-success-profile.html
+++ b/src/pages/page-email-success-profile.html
@@ -20,74 +20,74 @@ This code may only be used under the license found at https://github.com/swarmci
     Page specific styles, if the style is used on more than one page, moveit to shared styles.
     -->
         <style include="shared-styles">
-          :host {
-              @apply --titlepage-closed;
-            }
-
-            .container {
-                background-image: var(--sc-bg);
-              @apply --titlepage-closed-container;
-            }
-            .container .top {
-              @apply --titlepage-closed-container-top;
-            }
-            .container .bottom {
-              @apply --titlepage-closed-container-bottom;
-            }
-            .container .title {
-              @apply --titlepage-title;
-              color: var(--sc-blue);
-            }
-            .container .subtitle {
-              @apply --titlepage-subtitle;
-              color: var(--sc-grey4);
-            }
-
-            .container[wide-layout] {
-              @apply --titlepage-closed-wide-container;
-            }
-            .container[wide-layout] .top {
-              @apply --titlepage-closed-wide-container-top;
-            }
-            .container[wide-layout] .bottom {
-              @apply --titlepage-closed-wide-container-bottom;
-            }
-            .container[wide-layout] .title {
-              @apply --titlepage-title-wide;
-            }
-            .container[wide-layout] .subtitle {
-              @apply --titlepage-subtitle-wide;
-            }
-
-            .button {
-                @apply --layout-horizontal;
-                @apply --layout-center-justified;
-                @apply --text-button-big-fullwhite;
-                white-space: nowrap;
-                width: 100%;
-                max-width: 320px;
-            }
-
-            .container[wide-layout] .button {
-                margin-top: 0px;
-            }
-
-            .button:active {
-                @apply --button-active;
-            }
-
-            .bluetext {
-                @apply --small-bold;
-                cursor: pointer;
-                color: var(--sc-blue);
-                border-bottom: 2px dotted var(--sc-blue);
-                margin-top: 4vh;
-            }
-
-            .flexer {
-               @apply --titlepage-flexer;
-            }
-
+                :host {
+                    @apply --titlepage-closed;
+                  }
+      
+                  .container {
+                      background-image: var(--sc-bg);
+                    @apply --titlepage-closed-container;
+                  }
+                  .container .top {
+                    @apply --titlepage-closed-container-top;
+                  }
+                  .container .bottom {
+                    @apply --titlepage-closed-container-bottom;
+                  }
+                  .container .title {
+                    @apply --titlepage-title;
+                    color: var(--sc-blue);
+                  }
+                  .container .subtitle {
+                    @apply --titlepage-subtitle;
+                    color: var(--sc-grey4);
+                  }
+      
+                  .container[wide-layout] {
+                    @apply --titlepage-closed-wide-container;
+                  }
+                  .container[wide-layout] .top {
+                    @apply --titlepage-closed-wide-container-top;
+                  }
+                  .container[wide-layout] .bottom {
+                    @apply --titlepage-closed-wide-container-bottom;
+                  }
+                  .container[wide-layout] .title {
+                    @apply --titlepage-title-wide;
+                  }
+                  .container[wide-layout] .subtitle {
+                    @apply --titlepage-subtitle-wide;
+                  }
+      
+                  .button {
+                      @apply --layout-horizontal;
+                      @apply --layout-center-justified;
+                      @apply --text-button-big-fullwhite;
+                      white-space: nowrap;
+                      width: 100%;
+                      max-width: 320px;
+                  }
+      
+                  .container[wide-layout] .button {
+                      margin-top: 0px;
+                  }
+      
+                  .button:active {
+                      @apply --button-active;
+                  }
+      
+                  .bluetext {
+                      @apply --small-bold;
+                      cursor: pointer;
+                      color: var(--sc-blue);
+                      border-bottom: 2px dotted var(--sc-blue);
+                      margin-top: 4vh;
+                  }
+      
+                  .flexer {
+                     @apply --titlepage-flexer;
+                  }
+      
         </style>
 
         <app-location route="{{route}}"></app-location>
@@ -100,7 +100,8 @@ This code may only be used under the license found at https://github.com/swarmci
             </div>
             <div class="flexer"></div>
             <div class="bottom">
-                <div class="button" on-click="_back">{{localize('back to profile')}}</div>
+                <div class="button" on-click="_enter">{{localize('enter swarm.city')}}</div>
+                <!-- <div class="bluetext">{{localize('convert my ARC')}}</div> -->
             </div>
         </div>
 

--- a/src/pages/page-make-backup-profile.html
+++ b/src/pages/page-make-backup-profile.html
@@ -13,6 +13,7 @@ This code may only be used under the license found at https://github.com/swarmci
     Displays and shared styles only
 -->
 <link rel="import" href="../shared-styles.html">
+<link rel="import" href="../displays/display-unlock.html">
 
 <dom-module id="page-make-backup-profile">
     <template>
@@ -20,36 +21,43 @@ This code may only be used under the license found at https://github.com/swarmci
     Page specific styles, if the style is used on more than one page, moveit to shared styles.
     -->
         <style include="shared-styles">
-            :host {
-              @apply --titlepage-open;
+              :host {
+                @apply --titlepage-open;
             }
 
             .container {
-              background-image: var(--sc-bg);
-              @apply --titlepage-open-container;
+                background-image: var(--sc-bg);
+                @apply --titlepage-open-container;
             }
+
             .container .top {
-              @apply --titlepage-open-container-top;
+                @apply --titlepage-open-container-top;
             }
+
             .container .bottom {
-              @apply --titlepage-open-container-bottom;
+                @apply --titlepage-open-container-bottom;
             }
+
             .container .title {
-              @apply --titlepage-title;
-              color: var(--sc-grey3b);
+                @apply --titlepage-title;
+                color: var(--sc-grey3b);
             }
 
             .container[wide-layout] {
-              @apply --titlepage-open-wide-container;
+                @apply --titlepage-open-wide-container;
             }
+
             .container[wide-layout] .top {
-              @apply --titlepage-open-wide-container-top;
+                @apply --titlepage-open-wide-container-top;
             }
+
             .container[wide-layout] .bottom {
-              @apply --titlepage-open-wide-container-bottom;
+                @apply --titlepage-open-wide-container-bottom;
+                @apply --layout-flex;
             }
+
             .container[wide-layout] .title {
-              @apply --titlepage-title-wide;
+                @apply --titlepage-title-wide;
             }
 
             .close {
@@ -61,36 +69,35 @@ This code may only be used under the license found at https://github.com/swarmci
                 @apply --button-active;
             }
 
-
-
             .container .buttons {
                 @apply --layout-vertical;
                 @apply --layout-center-justified;
                 @apply --layout-center;
                 width: 100%;
             }
+
             .container[wide-layout] .buttons {
                 @apply --layout-vertical;
                 @apply --layout-start-justified;
                 @apply --layout-start;
             }
 
-
             .container .emailbtn {
                 @apply --text-button-big-fullwhite;
                 color: var(--sc-blue);
                 box-sizing: border-box;
                 width: 100%;
-                margin: 0 0 14px 0;            
+                margin: 0 0 14px 0;
             }
+
             .container .emailbtn:active {
                 @apply --button-active;
             }
+
             .container[wide-layout] .emailbtn {
                 margin: 0 0 14px 0;
                 max-width: 320px;
             }
-
 
             .container .downloadbtn {
                 @apply --text-button-big-fullwhite;
@@ -99,15 +106,15 @@ This code may only be used under the license found at https://github.com/swarmci
                 width: 100%;
                 margin: 0;
             }
+
             .container .downloadbtn :active {
                 @apply --button-active;
             }
-            .container[wide-layout] .downloadbtn  {
+
+            .container[wide-layout] .downloadbtn {
                 margin: 0;
                 max-width: 320px;
             }
-
-
 
             .container .trianglecontainer {
                 @apply --layout-horizontal;
@@ -132,7 +139,7 @@ This code may only be used under the license found at https://github.com/swarmci
                 padding: 54px 25px 40px;
                 box-sizing: border-box;
                 background-color: var(--sc-white);
-                max-width:700px;
+                max-width: 700px;
                 margin-bottom: 10vh;
             }
 
@@ -153,13 +160,21 @@ This code may only be used under the license found at https://github.com/swarmci
                 text-align: left;
             }
 
+            .container .bluetext-margins {
+                margin: 30px 0 60px 0;
+            }
+
             .container .bluetext {
                 @apply --small-bold;
                 cursor: pointer;
                 color: var(--sc-blue);
                 border-bottom: 2px dotted var(--sc-blue);
-                margin: 30px 0 60px 0;
             }
+
+            .blur {
+                @apply --unlock-blur;
+            }
+
 
             @media only screen and (-webkit-min-device-pixel-ratio: 1.5),
             only screen and (min--moz-device-pixel-ratio: 1.5),
@@ -173,7 +188,7 @@ This code may only be used under the license found at https://github.com/swarmci
 
         <app-location route="{{route}}"></app-location>
         <iron-media-query query="(min-width: 600px)" query-matches="{{wide}}"></iron-media-query>
-        <div class="container" wide-layout$="{{wide}}">
+        <div id="container" class="container" wide-layout$="{{wide}}">
             <div class="top">
                 <div class="close" on-click="_close"></div>
                 <div class="title">{{localize('Make a backup.')}}</div>
@@ -190,12 +205,25 @@ This code may only be used under the license found at https://github.com/swarmci
             </div>
             <div class="bottom">
                 <div class="buttons">
-                    <div class="emailbtn" on-click="_mail">{{localize('email my file')}}</div>
+                    <div class="emailbtn" on-click="_unlock">print paper wallet</div>
                     <div class="downloadbtn" on-click="_download">{{localize('download my file')}}</div>
                 </div>
-                <div class="bluetext" on-click="_toKeys">{{localize('show my keys')}}</div>
+                <div class="bluetext-margins">
+                    <span class="bluetext" on-click="_toKeys">{{localize('show my keys')}}</span>
+                </div>
             </div>
         </div>
+        <dom-if if="{{toggleUnlock}}">
+            <template>
+                <display-unlock 
+                    color="white"
+                    toggle-unlock="{{toggleUnlock}}" 
+                    private-key="{{privateKey}}" 
+                    qr-code-private-key="{{qrCodePrivateKey}}"
+                    qr-code-public-key="{{qrCodePublicKey}}">
+                </display-unlock>
+            </template>
+        </dom-if>
 
     </template>
 

--- a/src/pages/page-make-backup.html
+++ b/src/pages/page-make-backup.html
@@ -175,6 +175,7 @@ This code may only be used under the license found at https://github.com/swarmci
                 @apply --unlock-blur;
             }
 
+
             @media only screen and (-webkit-min-device-pixel-ratio: 1.5),
             only screen and (min--moz-device-pixel-ratio: 1.5),
             only screen and (min-resolution: 240dpi) {


### PR DESCRIPTION
Copied the code of the 'original pages' (download-succes, make-backup). The -profile-pages still need some logic, provided by @n3xco , for implementing the display-unlock, but there is another issue for that. 

P.S.: since the e-mail-option on make-backup is gone, can't 'page-email-success.html' and 'page-email-success-profile.html' be removed @bkawk ?