### PR TITLE
fixed #153

### DIFF
--- a/src/pages/page-new-here.html
+++ b/src/pages/page-new-here.html
@@ -124,7 +124,7 @@ This code may only be used under the license found at https://github.com/swarmci
             }
 
             .flexer {
-               @apply --titlepage-flexer;
+                @apply --titlepage-flexer;
             }
 
             @media only screen and (-webkit-min-device-pixel-ratio: 1.5),

--- a/src/swarm-city.html
+++ b/src/swarm-city.html
@@ -132,6 +132,10 @@
           hashtags: {
             type: Array,
           },
+          route: {
+            type: Object,
+            observer: '_routeChange',
+          },
           routeHistory: {
             type: Array,
             observer: '_loadAnimations',
@@ -300,6 +304,35 @@
       }
       _showPage404() {
         this.page = 'view404';
+      }
+
+      _routeChange() {
+        this._ifAccountAvoidEntryFlow();
+      }
+
+      _ifAccountAvoidEntryFlow() {
+        let entryFlowPages = [
+          'new-here',
+          'choose-avatar-and-username',
+          'choose-password',
+          'password-warning',
+        ];
+        if (entryFlowPages.includes(this.routeHistory[1])) {
+          if (this.routeHistory[0] != this.routeHistory[1]) {
+            if (entryFlowPages.indexOf(this.routeHistory[1])
+            - entryFlowPages.indexOf(this.routeHistory[0]) == 1) {
+              let storage = JSON.parse(localStorage.getItem('SwarmCity'));
+              if (storage.user && storage.user.username) {
+                this.set('route.path', 'hashtag-list');
+              }
+            }
+          } else {
+                let storage = JSON.parse(localStorage.getItem('SwarmCity'));
+                if (storage.user && storage.user.username) {
+                  this.set('route.path', 'hashtag-list');
+            }
+          }
+        }
       }
 
       _loadAnimations() {


### PR DESCRIPTION
Added an observer to route object on swarm-city.html

This observer checks if the go-to page is contained in list of entry-flow pages ( 'new-here', 'choose-avatar-and-username', 'choose-password', 'password-warning', ).

If go-to page is one of these, if it's not also the previous page (indicative of direct link), it checks if previous page wasn't the previous page in entry-flow.

Then it checks for exising username from redux. If there is one, the user will be redirected to page-hashtag-list.

Fixes #153