### PR TITLE
redraw canvas on rentry (by routeEntry)

### DIFF
--- a/src/displays/display-resize-avatar.html
+++ b/src/displays/display-resize-avatar.html
@@ -280,6 +280,14 @@
                         observer: '_drawFile',
                     },
                     /**
+                    * routeEntry triggers the entry animations
+                    * @type {Array}
+                    */
+                    routeEntry: {
+                        type: Array,
+                        observer: '_loadEntryAnimations',
+                    },                    
+                    /**
                     * The ending Y position on mouse up
                     * @type {Number}
                     */
@@ -462,6 +470,10 @@
                     }
                 }
             }
+
+            _loadEntryAnimations() {
+                this._firstLoad();
+            }            
 
             /**
             * Fired when user selects the X back button, routs to previous page

--- a/src/displays/display-resize-avatar.html
+++ b/src/displays/display-resize-avatar.html
@@ -203,6 +203,7 @@
                     */
                     routeEntry: {
                         type: Array,
+                        observer: '_loadEntryAnimations',
                     },
                     /**
                     * The image
@@ -279,14 +280,6 @@
                         value: 0,
                         observer: '_drawFile',
                     },
-                    /**
-                    * routeEntry triggers the entry animations
-                    * @type {Array}
-                    */
-                    routeEntry: {
-                        type: Array,
-                        observer: '_loadEntryAnimations',
-                    },                    
                     /**
                     * The ending Y position on mouse up
                     * @type {Number}
@@ -473,7 +466,7 @@
 
             _loadEntryAnimations() {
                 this._firstLoad();
-            }            
+            }
 
             /**
             * Fired when user selects the X back button, routs to previous page


### PR DESCRIPTION
in order to make sure that the saved avatar will be shown and not the previously canceled image.