### PR TITLE
fix the animations not showing on second entry to page 

### DIFF
--- a/src/pages/page-make-backup.html
+++ b/src/pages/page-make-backup.html
@@ -265,6 +265,16 @@ This code may only be used under the license found at https://github.com/swarmci
                         value: false,
                         observer: '_blur',
                     },
+
+                    /**
+                    * elements off screen (because of ExitAnimations)
+                    * @type {Boolean}
+                    */
+                    elementsOffScreen: {
+                        type: Boolean,
+                        value: false,
+                    },
+
                 };
             }
             connectedCallback() {
@@ -310,6 +320,7 @@ This code may only be used under the license found at https://github.com/swarmci
                         if (this.routeExit[1] == 'download-success'||
                             this.routeExit[1] == 'print-success' ||
                             this.routeExit[1] == 'my-keys') {
+                            this.elementsOffScreen = true;
                             // Here come the Exit Animations, going to page download-success
                             this.$.title.animate(
                                 [
@@ -391,22 +402,24 @@ This code may only be used under the license found at https://github.com/swarmci
                 }
             }
 
+
             _loadEntryAnimations() {
                 if (this.routeExit[0] != this.routeExit[1]) {
                     if (this.routeExit[1] == this.pageID) {
                     // Here come the Entry Animations
                     if (this.routeExit[0] == 'download-success'||
                         this.routeExit[0] == 'print-success'||
-                        this.routeExit[0] == 'my-keys') {
+                        this.routeExit[0] == 'my-keys' ||
+                        this.elementsOffScreen) {
                         // Coming from page download-success
                         this.$.title.animate(
                             [
-                                {'transform': 'translateX(-100vw)'},
+                                {'transform': 'translateX('+(this.elementsOffScreen?0:-100)+'vw)'},
                                 {'transform': 'translateX(0px)'},
                             ],
                             {
                                 fill: 'forwards',
-                                duration: 200,
+                                duration: this.elementsOffScreen?0:200,
                                 iterations: 1,
                                 iterationStart: 0,
                                 easing: 'cubic-bezier(0.42,0,0.177,0.751)',
@@ -416,12 +429,12 @@ This code may only be used under the license found at https://github.com/swarmci
                         );
                         this.$.trianglecontainer.animate(
                             [
-                                {'transform': 'translateX(-100vw)'},
+                                {'transform': 'translateX('+(this.elementsOffScreen?0:-100)+'vw)'},
                                 {'transform': 'translateX(0px)'},
                             ],
                             {
                                 fill: 'forwards',
-                                duration: 200,
+                                duration: this.elementsOffScreen?0:200,
                                 iterations: 1,
                                 iterationStart: 0,
                                 easing: 'cubic-bezier(0.42,0,0.177,0.751)',
@@ -431,12 +444,12 @@ This code may only be used under the license found at https://github.com/swarmci
                         );
                         this.$.content.animate(
                             [
-                                {'transform': 'translateX(-100vw)'},
+                                {'transform': 'translateX('+(this.elementsOffScreen?0:-100)+'vw)'},
                                 {'transform': 'translateX(0px)'},
                             ],
                             {
                                 fill: 'forwards',
-                                duration: 200,
+                                duration: this.elementsOffScreen?0:200,
                                 iterations: 1,
                                 iterationStart: 0,
                                 easing: 'cubic-bezier(0.42,0,0.177,0.751)',
@@ -446,12 +459,13 @@ This code may only be used under the license found at https://github.com/swarmci
                         );
                         this.$.buttons.animate(
                             [
-                                {'transform': 'translateX(-20vw)', 'opacity': '0'},
+                                {'transform': 'translateX('+(this.elementsOffScreen?0:-20)+'vw)',
+                                   'opacity': '0'},
                                 {'transform': 'translateX(0px)', 'opacity': '1'},
                             ],
                             {
                                 fill: 'forwards',
-                                duration: 200,
+                                duration: this.elementsOffScreen?0:200,
                                 iterations: 1,
                                 iterationStart: 0,
                                 easing: 'cubic-bezier(0.42,0,0.177,0.751)',
@@ -461,12 +475,13 @@ This code may only be used under the license found at https://github.com/swarmci
                         );
                         this.$.keys.animate(
                             [
-                                {'transform': 'translateX(-20vw)', 'opacity': '0'},
+                                {'transform': 'translateX('+(this.elementsOffScreen?0:-20)+'vw)',
+                                   'opacity': '0'},
                                 {'transform': 'translateX(0px)', 'opacity': '1'},
                             ],
                             {
                                 fill: 'forwards',
-                                duration: 200,
+                                duration: this.elementsOffScreen?0:200,
                                 iterations: 1,
                                 iterationStart: 0,
                                 easing: 'cubic-bezier(0.42,0,0.177,0.751)',
@@ -474,6 +489,7 @@ This code may only be used under the license found at https://github.com/swarmci
                                 endDelay: 0,
                             }
                         );
+                        this.elementsOffScreen = false;
                     }
                 }
             }

--- a/src/pages/page-restore-account.html
+++ b/src/pages/page-restore-account.html
@@ -180,6 +180,16 @@ This code may only be used under the license found at https://github.com/swarmci
                         type: Boolean,
                         statePath: 'iphone',
                     },
+
+                    /**
+                    * elements off screen (because of ExitAnimations)
+                    * @type {Boolean}
+                    */
+                    elementsOffScreen: {
+                        type: Boolean,
+                        value: false,
+                    },
+
                 };
             }
 
@@ -224,6 +234,7 @@ This code may only be used under the license found at https://github.com/swarmci
             if (this.routeExit[0] != this.routeExit[1]) {
                     if (this.routeExit[0] == this.pageID) {
                         // Here come the Exit Animations
+                        this.elementsOffScreen = true;
                         if (this.routeExit[1] == 'new-here') {
                             // Here come the Exit Animations, going to page new-here
                             this.$.title.animate(
@@ -329,16 +340,16 @@ This code may only be used under the license found at https://github.com/swarmci
                 if (this.routeExit[0] != this.routeExit[1]) {
                     if (this.routeExit[1] == this.pageID) {
                     // Here come the Entry Animations
-                        if (this.routeExit[0] == 'new-here') {
+                        if (this.routeExit[0] == 'new-here' || this.elementsOffScreen) {
                             // Coming from page new-here
                             this.$.title.animate(
                                 [
-                                    {'transform': 'translateX(100vw)'},
+                                    {'transform': 'translateX('+(this.elementsOffScreen?0:100)+'vw)'},
                                     {'transform': 'translateX(0px)'},
                                 ],
                                 {
                                     fill: 'forwards',
-                                    duration: 200,
+                                    duration: this.elementsOffScreen?0:200,
                                     iterations: 1,
                                     iterationStart: 0,
                                     easing: 'cubic-bezier(0.42,0,0.177,0.751)',
@@ -353,7 +364,7 @@ This code may only be used under the license found at https://github.com/swarmci
                                 ],
                                 {
                                     fill: 'forwards',
-                                    duration: 200,
+                                    duration: this.elementsOffScreen?0:200,
                                     iterations: 1,
                                     iterationStart: 0,
                                     easing: 'cubic-bezier(0.42,0,0.177,0.751)',
@@ -363,12 +374,13 @@ This code may only be used under the license found at https://github.com/swarmci
                             );
                             this.$.buttons.animate(
                                 [
-                                    {'transform': 'translateX(20vw)', 'opacity': '0'},
+                                    {'transform': 'translateX('+(this.elementsOffScreen?0:20)+'vw)',
+                                       'opacity': '0'},
                                     {'transform': 'translateX(0px)', 'opacity': '1'},
                                 ],
                                 {
                                     fill: 'forwards',
-                                    duration: 200,
+                                    duration: this.elementsOffScreen?0:200,
                                     iterations: 1,
                                     iterationStart: 0,
                                     easing: 'cubic-bezier(0.42,0,0.177,0.751)',
@@ -382,12 +394,12 @@ This code may only be used under the license found at https://github.com/swarmci
                             // Coming from page private-key
                             this.$.title.animate(
                                 [
-                                    {'transform': 'translateX(-100vw)'},
+                                    {'transform': 'translateX('+(this.elementsOffScreen?0:-100)+'vw)'},
                                     {'transform': 'translateX(0px)'},
                                 ],
                                 {
                                     fill: 'forwards',
-                                    duration: 200,
+                                    duration: this.elementsOffScreen?0:200,
                                     iterations: 1,
                                     iterationStart: 0,
                                     easing: 'cubic-bezier(0.42,0,0.177,0.751)',
@@ -402,7 +414,7 @@ This code may only be used under the license found at https://github.com/swarmci
                                 ],
                                 {
                                     fill: 'forwards',
-                                    duration: 200,
+                                    duration: this.elementsOffScreen?0:200,
                                     iterations: 1,
                                     iterationStart: 0,
                                     easing: 'cubic-bezier(0.42,0,0.177,0.751)',
@@ -412,12 +424,13 @@ This code may only be used under the license found at https://github.com/swarmci
                             );
                             this.$.buttons.animate(
                                 [
-                                    {'transform': 'translateX(-20vw)', 'opacity': '0'},
+                                    {'transform': 'translateX('+(this.elementsOffScreen?0:-20)+'vw)',
+                                       'opacity': '0'},
                                     {'transform': 'translateX(0px)', 'opacity': '1'},
                                 ],
                                 {
                                     fill: 'forwards',
-                                    duration: 200,
+                                    duration: this.elementsOffScreen?0:200,
                                     iterations: 1,
                                     iterationStart: 0,
                                     easing: 'cubic-bezier(0.42,0,0.177,0.751)',
@@ -425,6 +438,7 @@ This code may only be used under the license found at https://github.com/swarmci
                                     endDelay: 0,
                                 }
                             );
+                            this.elementsOffScreen = false;
                         }
                     }
                 }

--- a/src/swarm-city.html
+++ b/src/swarm-city.html
@@ -189,6 +189,14 @@
           routeData: Object,
           subroute: String,
           rootPath: String,
+          offScreenPages: {
+            Type: Array,
+            value: [],
+          },
+          exitOpacity0Pages: {
+            Type: Array,
+            value: [],
+          },
         };
       }
 
@@ -284,21 +292,65 @@
         }
       }
 
-      _loadAnimations() {
-        if (this.routeExit[0] != this.routeExit[1]) {
-          let transitionFound = false;
-          for (let i = 1; i < this.animationsArray.length; i++) {
-            if (this.animationsArray[i].from == this.routeExit[0]
-              && this.animationsArray[i].to == this.routeExit[1]) {
-              this.animations = this.animationsArray[i];
-              transitionFound = true;
+        _loadAnimations() {
+            if (this.routeExit[0] != this.routeExit[1]) {
+                let transitionFound = false;
+                for (let i = 1; i < this.animationsArray.length; i++) {
+                    if (this.animationsArray[i].from == this.routeExit[0]
+                    && this.animationsArray[i].to == this.routeExit[1]) {
+                    this.animations = this.animationsArray[i];
+                    transitionFound = true;
+                    }
+                }
+                let offScreen = this.offScreenPages.includes(this.routeExit[1]);
+                let opacity0 = this.exitOpacity0Pages.includes(this.routeExit[1]);
+                if (!transitionFound) {
+                    this.animations = this.animationsArray[0];
+                }
+                if (offScreen) {
+                    this.animations.entryAnimation.descriptionArray.forEach(function(entry) {
+                        entry.transform='translate(0)';
+                    });
+                    this.animations.entryAnimation.descriptionObject.duration=0;
+                    this._removeItemFromArray(this.offScreenPages, this.routeExit[0]);
+                }
+                if (opacity0) {
+                    this.animations.entryAnimation.descriptionArray.forEach(function(entry) {
+                        entry.opacity =1;
+                    });
+                    this.animations.entryAnimation.descriptionObject.duration=0;
+                    this._removeItemFromArray(this.exitOpacity0Pages, this.routeExit[0]);
+                }
+                if (this._isPageHasTransform(this.animations.exitAnimation.descriptionArray)) {
+                    this.offScreenPages.push(this.routeExit[0]);
+                }
+                if (this._isPageExitOpacity0(this.animations.exitAnimation.descriptionArray)) {
+                    this.exitOpacity0Pages.push(this.routeExit[0]);
+                }
             }
-          }
-          if (!transitionFound) {
-            this.animations = this.animationsArray[0];
-          }
         }
-      }
+
+        _removeItemFromArray(array, item) {
+            for (let i = array.length - 1; i >= 0; i--) {
+                if (array[i] === item) {
+                    array.splice(i, 1);
+                }
+            }
+        }
+
+        _isPageHasTransform(pageDescriptionArray) {
+            let res=false;
+            pageDescriptionArray.forEach(function(entry) {
+                if (entry.transform) {
+                    res=true;
+                }
+            });
+            return res;
+        }
+
+        _isPageExitOpacity0(pageDescriptionArray) {
+            return pageDescriptionArray[pageDescriptionArray.length - 1].opacity ==0;
+        }
     }
     window.customElements.define(SwarmCity.is, SwarmCity);
   </script>


### PR DESCRIPTION
The issue happens when the animation is 'exited' off screeen on animationExit.

There are two separate issues:
1) webcomponents: the reset is handled within the webcomponent.
2) pages: the animation is defined in sc-animation, and can be default or custom. also the the animation can be exited by 'transform' off screen, or by setting opacity to 0 (or both).

For the pages issues, I fixed in swarm-city.html by keeping track inside array all pages that were 'exited' (separately for 'transform' and 'opacity=0')
